### PR TITLE
adding arbitrum references to readme and updating link format

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,32 +4,36 @@ Caching dao analytic data for all moloch daos summoned on daohaus.club.
 
 ## Endpoints
 
-https://api.thegraph.com/subgraphs/name/odyssy-automaton/daohaus-stats
+[daohaus-stats](https://api.thegraph.com/subgraphs/name/odyssy-automaton/daohaus-stats)
 
-https://api.thegraph.com/subgraphs/name/odyssy-automaton/daohaus-stats-kovan
+[daohaus-stats-kovan](https://api.thegraph.com/subgraphs/name/odyssy-automaton/daohaus-stats-kovan)
 
-https://api.thegraph.com/subgraphs/name/odyssy-automaton/daohaus-stats-rinkeby
+[daohaus-stats-rinkeby](https://api.thegraph.com/subgraphs/name/odyssy-automaton/daohaus-stats-rinkeby)
 
-https://api.thegraph.com/subgraphs/name/odyssy-automaton/daohaus-stats-xdai
+[daohaus-stats-xdai](https://api.thegraph.com/subgraphs/name/odyssy-automaton/daohaus-stats-xdai)
 
-http://35.224.233.211/subgraphs/name/matic/daohaus
+[daohaus-stats-arbitrum](https://api.thegraph.com/subgraphs/name/odyssy-automaton/daohaus-stats-arbitrum)
+
+[daohaus-stats-matic](http://35.224.233.211/subgraphs/name/matic/daohaus)
 
 ## Graph explorers
 
-https://thegraph.com/explorer/subgraph/odyssy-automaton/daohaus-stats
+[daohaus-stats](https://thegraph.com/explorer/subgraph/odyssy-automaton/daohaus-stats)
 
-https://thegraph.com/explorer/subgraph/odyssy-automaton/daohaus-stats-kovan
+[daohaus-stats-kovan](https://thegraph.com/explorer/subgraph/odyssy-automaton/daohaus-stats-kovan)
 
-https://thegraph.com/explorer/subgraph/odyssy-automaton/daohaus-stats-rinkeby
+[daohaus-stats-rinkeby](https://thegraph.com/explorer/subgraph/odyssy-automaton/daohaus-stats-rinkeby)
 
-https://thegraph.com/explorer/subgraph/odyssy-automaton/daohaus-stats-xdai
+[daohaus-stats-xdai](https://thegraph.com/explorer/subgraph/odyssy-automaton/daohaus-stats-xdai)
 
-http://35.224.233.211/subgraphs/name/matic/daohaus/graphql
+[daohaus-stats-arbitrum](https://thegraph.com/explorer/subgraph/odyssy-automaton/daohaus-stats-arbitrum)
+
+[daohaus-stats-matic](http://35.224.233.211/subgraphs/name/matic/daohaus/graphql)
 
 
 ### License
 
-The DAOhaus subgraphs are for querying data for Moloch DAOs built on the Moloch DAO framework smart contracts <https://github.com/MolochVentures/moloch>. 
+The DAOhaus subgraphs are for querying data for Moloch DAOs built on the Moloch DAO framework smart contracts <https://github.com/MolochVentures/moloch>.
 
 Copyright (C) 2021 DAOhaus
 


### PR DESCRIPTION
was investigating the different repos across HausDAO and saw Arbitrum links missing - adding them with this pr and converting to markdown links - just a small cleanup task if you want to merge it

```
# Links added
daohaus-stats-arbitrum - https://api.thegraph.com/subgraphs/name/odyssy-automaton/daohaus-stats-arbitrum
daohaus-stats-arbitrum - https://thegraph.com/explorer/subgraph/odyssy-automaton/daohaus-stats-arbitrum
```

![Screen Shot 2022-03-24 at 9 50 13 AM](https://user-images.githubusercontent.com/5998100/159956554-f042d17c-101b-4442-960c-423805d015f6.png)
